### PR TITLE
Change old -reduce_inv to new -support flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note that unless specified it is expected that the *test_arguments.xml* file is 
     &ltarg&gt-pdr_max 0&lt/arg&gt
     &ltarg&gt-smooth&lt/arg&gt
     &ltarg&gt-interval&lt/arg&gt
-    &ltarg&gt-reduce_inv&lt/arg&gt
+    &ltarg&gt-support&lt/arg&gt
     &ltarg&gt-no_bmc&lt/arg&gt
     &ltarg&gt-no_inv_gen&lt/arg&gt
     &ltarg&gt-induct_cex&lt/arg&gt

--- a/default_args.xml
+++ b/default_args.xml
@@ -25,6 +25,6 @@
     <arg></arg>
     <arg>-smooth</arg>
     <arg>-interval</arg>
-    <arg>-reduce_inv</arg>
+    <arg>-support</arg>
   </ArgumentGroup>
 </Configuration>

--- a/test_arguments.xml
+++ b/test_arguments.xml
@@ -13,7 +13,7 @@
     <arg>-pdr_max 0</arg>
     <arg>-smooth</arg>
     <arg>-interval</arg>
-    <arg>-reduce_inv</arg>
+    <arg>-support</arg>
     <arg>-no_bmc</arg>
     <arg>-no_inv_gen</arg>
     <arg>-induct_cex</arg>


### PR DESCRIPTION
The old -reduce_inv option has been generalized to a new -support option. This updates the regressions to match.
